### PR TITLE
Normalize  message object

### DIFF
--- a/force-app/main/default/aura/ContinuationProxy/ContinuationProxyController.js
+++ b/force-app/main/default/aura/ContinuationProxy/ContinuationProxyController.js
@@ -41,7 +41,7 @@
             methodParams: args.methodParams
         };
         var vf = component.find("vfFrame").getElement().contentWindow;
-        vf.postMessage(message, vfBaseURL);
+        vf.postMessage(JSON.parse(JSON.stringify(message)), vfBaseURL);
     }
 
 })


### PR DESCRIPTION
Fixes #2 by normalizing the message object which, for some reason, can't be cloned by javascript later on.